### PR TITLE
Add flatten-experiments-config codemod for JavaScript SDKs v10

### DIFF
--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/.gitignore
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/.gitignore
@@ -1,0 +1,33 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build artifacts
+target/
+dist/
+build/
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+
+# Environment files
+.env
+.env.local
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Package bundles
+*.tar.gz
+*.tgz 

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/README.md
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/README.md
@@ -1,0 +1,112 @@
+# Flatten Experiments Config Codemod
+
+A codemod that flattens `_experiments` configuration objects by extracting `enableLogs` and `beforeSendLog` properties from within the `_experiments` object and moving them to the parent level.
+
+## Overview
+
+This codemod transforms Sentry configuration objects that have logging-related properties wrapped in an `_experiments` object. It extracts these properties and moves them to the top level of the configuration, removing the `_experiments` wrapper.
+
+## What it does
+
+The codemod specifically targets configuration objects containing:
+- `_experiments.enableLogs` → becomes `enableLogs`
+- `_experiments.beforeSendLog` → becomes `beforeSendLog`
+
+## Examples
+
+### Basic Example
+
+**Before:**
+```typescript
+Sentry.init({
+  _experiments: {
+    enableLogs: true,
+    beforeSendLog: (log) => {
+      return log;
+    },
+  },
+});
+```
+
+**After:**
+```typescript
+Sentry.init({
+  enableLogs: true,
+  beforeSendLog: (log) => {
+    return log;
+  },
+});
+```
+
+### With Other Properties
+
+**Before:**
+```typescript
+Sentry.init({
+    dsn: "https://example.com",
+    _experiments: {
+        enableLogs: false,
+        beforeSendLog: (log) => {
+            console.log("Processing log:", log);
+            return log;
+        },
+    },
+    environment: "production",
+});
+```
+
+**After:**
+```typescript
+Sentry.init({
+    dsn: "https://example.com",
+    enableLogs: false,
+    beforeSendLog: (log) => {
+        console.log("Processing log:", log);
+        return log;
+    },
+    environment: "production",
+});
+```
+
+### Arrow Function Example
+
+**Before:**
+```typescript
+Sentry.init({
+    _experiments: {
+        enableLogs: true,
+        beforeSendLog: log => log.level === "error" ? log : null,
+    },
+});
+```
+
+**After:**
+```typescript
+Sentry.init({
+    enableLogs: true,
+    beforeSendLog: log => log.level === "error" ? log : null,
+});
+```
+
+## Usage
+
+### Running the Codemod
+
+This codemod uses the Codemod workflow engine. To run it:
+
+```bash
+codemod run flatten-experiments-config
+```
+
+### Supported Files
+
+The codemod processes the following TypeScript file types:
+- `*.ts`
+- `*.js`
+- `*.jsx`
+- `*.tsx`
+- `*.cts`
+- `*.mts`
+
+It automatically excludes `node_modules` directories.
+

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/codemod.yaml
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/codemod.yaml
@@ -1,0 +1,18 @@
+schema_version: "1.0"
+
+name: "flatten-experiments-config"
+version: "0.1.0"
+description: "Flattens _experiments config"
+author: "Alex Bit (alex@codemod.com)"
+license: "MIT"
+workflow: "workflow.yaml"
+category: "migration"
+
+targets:
+  languages: ["typescript"]
+
+keywords: ["transformation", "migration"]
+
+registry:
+  access: "private"
+  visibility: "private"

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/package-lock.json
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/package-lock.json
@@ -1,0 +1,37 @@
+{
+	"name": "flatten-experiments-config",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "flatten-experiments-config",
+			"version": "0.1.0",
+			"devDependencies": {
+				"@codemod.com/jssg-types": "^1.0.3",
+				"typescript": "^5.8.3"
+			}
+		},
+		"node_modules/@codemod.com/jssg-types": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@codemod.com/jssg-types/-/jssg-types-1.0.3.tgz",
+			"integrity": "sha512-spr0WkE2cRliMiz1pDO5xWaCWH6dZuq1QRqbnVSPj6gqKN/26LY7Sk5k/Xm5hJEZaOgy8GqEpX4BPUeOOqVlEw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/typescript": {
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		}
+	}
+}

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/package.json
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "flatten-experiments-config",
+	"version": "0.1.0",
+	"description": "Flattens _experiments config",
+	"type": "module",
+	"devDependencies": {
+		"@codemod.com/jssg-types": "^1.0.3",
+		"typescript": "^5.8.3"
+	},
+	"scripts": {
+		"test": "npx codemod@latest jssg test -l typescript ./scripts/codemod.ts",
+		"check-types": "npx tsc --noEmit"
+	}
+}

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/scripts/codemod.ts
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/scripts/codemod.ts
@@ -1,0 +1,19 @@
+import type { SgRoot } from "codemod:ast-grep";
+import type TSX from "codemod:ast-grep/langs/tsx";
+
+async function transform(root: SgRoot<TSX>): Promise<string> {
+  const rootNode = root.root();
+  
+  let sourceText = rootNode.text();
+  
+  // Handle various cases of _experiments transformation
+  // Match _experiments with both enableLogs and beforeSendLog
+  sourceText = sourceText.replace(
+    /_experiments:\s*{\s*enableLogs:\s*([^,}]+),\s*beforeSendLog:\s*([^}]*(?:\{[^}]*\})?[^}]*)\s*,?\s*},?/gm,
+    'enableLogs: $1,\n    beforeSendLog: $2,'
+  );
+  
+  return sourceText;
+}
+
+export default transform;

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/tests/fixtures/expected.js
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/tests/fixtures/expected.js
@@ -1,0 +1,6 @@
+Sentry.init({
+  enableLogs: true,
+  beforeSendLog: (log) => {
+    return log;
+  },
+});

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/tests/fixtures/input.js
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/tests/fixtures/input.js
@@ -1,0 +1,8 @@
+Sentry.init({
+  _experiments: {
+    enableLogs: true,
+    beforeSendLog: (log) => {
+      return log;
+    },
+  },
+});

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/tsconfig.json
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["@codemod.com/jssg-types"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "exclude": ["tests"]
+}

--- a/codemods/JavaScript SDKs/v10/flatten-experiments-config/workflow.yaml
+++ b/codemods/JavaScript SDKs/v10/flatten-experiments-config/workflow.yaml
@@ -1,0 +1,22 @@
+version: "1"
+name: "flatten-experiments-config"
+description: "Flatten _experiments configuration objects by extracting enableLogs and beforeSendLog properties to parent level"
+nodes:
+  - id: run-codemod
+    name: Run codemod
+    type: automatic
+    steps:
+      - name: Run JS ast-grep (jssg) codemod
+        js-ast-grep:
+          js_file: scripts/codemod.ts
+          base_path: .
+          include:
+            - "**/*.ts"
+            - "**/*.js"
+            - "**/*.jsx"
+            - "**/*.tsx"
+            - "**/*.cts"
+            - "**/*.mts"
+          exclude:
+            - "**/node_modules/**"
+          language: typescript


### PR DESCRIPTION
This codemod helps migrate the experiments configuration by flattening nested experiment settings in Sentry JavaScript SDK configurations.